### PR TITLE
Potential fix for code scanning alert no. 50: Prototype-polluting assignment

### DIFF
--- a/venv/lib/python3.11/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
+++ b/venv/lib/python3.11/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
@@ -12,10 +12,18 @@ const encoder = new TextEncoder();
 self.addEventListener("message", async function (event) {
   if (event.data.close) {
     let connectionID = event.data.close;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error('Invalid connectionID:', connectionID);
+      return;
+    }
     delete connections[connectionID];
     return;
   } else if (event.data.getMore) {
     let connectionID = event.data.getMore;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error('Invalid connectionID:', connectionID);
+      return;
+    }
     let { curOffset, value, reader, intBuffer, byteBuffer } =
       connections[connectionID];
     // if we still have some in buffer, then just send it back straight away


### PR DESCRIPTION
Potential fix for [https://github.com/ryanapierce/ryanapierce.github.io/security/code-scanning/50](https://github.com/ryanapierce/ryanapierce.github.io/security/code-scanning/50)

To fix the prototype pollution issue, we need to ensure that the `connectionID` cannot be set to `__proto__`, `constructor`, or `prototype`. This can be achieved by adding a check to reject these values before using them as keys in the `connections` object.

The best way to fix the problem without changing existing functionality is to add a validation step before using `connectionID` to index the `connections` object. If `connectionID` is one of the forbidden values, we should handle it appropriately (e.g., by logging an error and returning early).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
