### PR TITLE
Potential fix for code scanning alert no. 47: Information exposure through an exception

### DIFF
--- a/application.py
+++ b/application.py
@@ -100,7 +100,7 @@ def chat():
 
     except Exception as e:
         logging.error(f"Unexpected Error: {str(e)}")
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "An internal error has occurred"}), 500
 
 if __name__ == "__main__":
     from waitress import serve


### PR DESCRIPTION
Potential fix for [https://github.com/ryanapierce/ryanapierce.github.io/security/code-scanning/47](https://github.com/ryanapierce/ryanapierce.github.io/security/code-scanning/47)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to end users. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the error and return a generic message.

1. Modify the exception handling block for the generic `Exception` on lines 101-103.
2. Log the detailed error message using the existing logging setup.
3. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
