### PR TITLE
Potential fix for code scanning alert no. 2: Unsafe jQuery plugin

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -95,8 +95,14 @@
 			}, userConfig);
 
 			// Expand "target" if it's not a jQuery object already.
-				if (typeof config.target != 'jQuery')
-					config.target = $(config.target);
+				if (!(config.target instanceof jQuery)) {
+					try {
+						config.target = $(config.target);
+					} catch (e) {
+						console.error('Invalid jQuery selector:', config.target);
+						config.target = $();
+					}
+				}
 
 		// Panel.
 


### PR DESCRIPTION
Potential fix for [https://github.com/ryanapierce/ryanapierce.github.io/security/code-scanning/2](https://github.com/ryanapierce/ryanapierce.github.io/security/code-scanning/2)

To fix the problem, we need to ensure that `config.target` is always a safe and valid jQuery object. Instead of directly using `$(config.target)`, we should validate and sanitize `config.target` to prevent any potential XSS attacks. One way to achieve this is to check if `config.target` is a valid CSS selector or a jQuery object before using it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
