### PR TITLE
Potential fix for code scanning alert no. 61: Unsafe jQuery plugin

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -97,9 +97,9 @@
 			// Expand "target" if it's not a jQuery object already.
 				if (!(config.target instanceof jQuery)) {
 					try {
-						config.target = $(config.target);
+						config.target = $.find(config.target);
 					} catch (e) {
-						console.error('Invalid jQuery selector:', config.target);
+						console.error('Invalid CSS selector:', config.target);
 						config.target = $();
 					}
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/ryanapierce/ryanapierce.github.io/security/code-scanning/61](https://github.com/ryanapierce/ryanapierce.github.io/security/code-scanning/61)

To fix the problem, we need to ensure that the `config.target` is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing the user input to the jQuery constructor. This change will ensure that the input is always interpreted as a CSS selector, thus preventing any potential XSS vulnerabilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
