### PR TITLE
Potential fix for code scanning alert no. 76: DOM text reinterpreted as HTML

### DIFF
--- a/assets/projects/about-me-chat-bot/templates/ask_about_me_chat.html
+++ b/assets/projects/about-me-chat-bot/templates/ask_about_me_chat.html
@@ -103,7 +103,7 @@
                     return;
                 }
     
-                $('#chatOutput').append('<p><strong>You:</strong> ' + userInput + '</p>');
+                $('#chatOutput').append('<p><strong>You:</strong> ' + escapeHtml(userInput) + '</p>');
     
                 $.ajax({
                     url: "https://8y33u4e087.execute-api.us-east-1.amazonaws.com/prod/chat",


### PR DESCRIPTION
Potential fix for [https://github.com/ryanapierce/ryanapierce.github.io/security/code-scanning/76](https://github.com/ryanapierce/ryanapierce.github.io/security/code-scanning/76)

To fix the problem, we need to ensure that the `userInput` is properly escaped before being inserted into the DOM. This can be done by using the `escapeHtml` function that is already defined in the script. We will replace the direct insertion of `userInput` with an escaped version of it.

- Modify the code on line 106 to use the `escapeHtml` function to sanitize the `userInput` before appending it to the DOM.
- No additional imports or definitions are needed as the `escapeHtml` function is already defined in the script.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
